### PR TITLE
typos/design decisions

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -1,8 +1,8 @@
-#<span style="color:red">Still under development -- not yet ready for prime time</span>
+# <span style="color:red">Still under development -- not yet ready for prime time</span>
 
 
 
-# Template for LinkML based schema's
+# Template for LinkML based schemas
 
 ## Requirements
 * __Python >= 3.7.1__


### PR DESCRIPTION
- Added space after # on first line to make it Markdown, not a shell comment
- Removed apostrophe from plural schema's